### PR TITLE
Add an endpoint to get the last known state of each probe in a stable order

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.17

--- a/src/main/scala/app/model/ProbateRegistry.scala
+++ b/src/main/scala/app/model/ProbateRegistry.scala
@@ -11,6 +11,7 @@ import java.nio.file.{Files, Paths, StandardOpenOption}
 import net.liftweb.json._
 import java.nio.charset.StandardCharsets
 
+import app.server.ProbeStatus
 import server.tea.{Model, State}
 
 case class ProbateState(checksExecuted: Long, incidentsReported: Long)
@@ -90,6 +91,11 @@ object Json {
   }
 
   def serialise(response: State) = {
+    implicit val formats = probateFormats
+    JsonParser.parse(write(response))
+  }
+
+  def serialise(response: List[(Probe, Option[ProbeStatus])]) = {
     implicit val formats = probateFormats
     JsonParser.parse(write(response))
   }

--- a/src/main/scala/app/model/Probe.scala
+++ b/src/main/scala/app/model/Probe.scala
@@ -56,5 +56,11 @@ case class CurrentProbeStatuses(probes: List[app.model.Probe]) {
     }
   })
 
-  def statuses = probeToStatus
+  // Retain the order of the probes
+  def statuses: List[(Probe, Option[ProbeStatus])] = probes.map(probe => (probe, probeToStatus.get(probe)))
+
+  def completedProbes: List[(Probe, ProbeStatus)] = statuses.collect {
+    case (probe, Some(status)) => (probe, status)
+  }
+
 }


### PR DESCRIPTION
Proposed endpoint is /state/probes, and it serialises `CurrentProbeStatuses` into a not particularly nice json format, but usable.

FYI the other /state endpoint doesn't appear to serialise anything useful except for the probe configurations.